### PR TITLE
Added docker_config_json paraneter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 * `aws_access_key_id`: *Optional.* AWS access key to use for acquiring ECR
   credentials.
 
+* `docker_config_json` : *Optional.* The raw `config.json` file used for authenticating with Docker registries. If specified, `username` and `password` parameters will be ignored. You may find this useful if you need to be authenticated against multiple registries (e.g. pushing to a private registry, but you also also need to pull authenticate to pull images from Docker Hub without being rate-limited).
+
 * `aws_secret_access_key`: *Optional.* AWS secret key to use for acquiring ECR
   credentials.
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -2,6 +2,9 @@ LOG_FILE=${LOG_FILE:-/tmp/docker.log}
 SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
 STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-120}
 
+# Otherwise we get "certificate relies on legacy Common Name field"
+export GODEBUG="x509ignoreCN=0"
+
 sanitize_cgroups() {
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
@@ -205,4 +208,10 @@ docker_pull() {
 
   printf "\n${RED}Failed to pull image %s.${NC}" "$1"
   return 1
+}
+
+docker_config_json_to_file() {
+  local docker_config_json="${1}"
+  mkdir -p ~/.docker
+  echo "${1}" > ~/.docker/config.json
 }

--- a/assets/in
+++ b/assets/in
@@ -28,6 +28,7 @@ registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
+docker_config_json=$(jq -r '.source.docker_config_json // ""' < $payload)
 repository="$(jq -r '.source.repository // ""' < $payload)"
 tag="$(jq -r '.source.tag // "latest"' < $payload)"
 ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
@@ -64,7 +65,11 @@ if [ "$skip_download" = "false" ]; then
     "$insecure_registries" \
     "$registry_mirror"
 
-  log_in "$username" "$password" "$registry"
+  if [ -z "$docker_config_json" ]; then
+    log_in "$username" "$password" "$registry"
+  else
+    docker_config_json_to_file "$docker_config_json"
+  fi
 
   docker_pull "$image_name"
 

--- a/assets/out
+++ b/assets/out
@@ -29,6 +29,7 @@ registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
+docker_config_json=$(jq -r '.source.docker_config_json // ""' < $payload)
 repository=$(jq -r '.source.repository // ""' < $payload)
 ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
@@ -52,7 +53,12 @@ start_docker \
 	"${max_concurrent_uploads}" \
 	"$insecure_registries" \
 	"$registry_mirror"
-log_in "$username" "$password" "$registry"
+  
+if [ -z "$docker_config_json" ]; then
+  log_in "$username" "$password" "$registry"
+else
+  docker_config_json_to_file "$docker_config_json"
+fi
 
 tag_source=$(jq -r '.source.tag // "latest"' < $payload)
 tag_params=$(jq -r '.params.tag_file // ""' < $payload)


### PR DESCRIPTION
This means you can specify a full ~/.docker/config.json file to use for
authentication, which is useful to work around Docker Hub's rate-limiting.

You can pass this in (e.g. from a secrets source such as Credhub or k8s
secrets), and authenticate against multiple registries.

Also added GODEBUG="x509ignoreCN=0" env var to work around "legacy CN"
format SSL certificates warning, introduced with latest version of Go SSL
library.